### PR TITLE
fix package #2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='degiro-api',
       author='Florian Katenbrink',
       author_email='f.katenbrink@gmail.com',
       license='MIT',
-      packages=['degiro'],
+      packages=find_packages(),
       install_requires=[
         'requests',
       ]


### PR DESCRIPTION
Fixes "no module named degiro" on pip install #2 
Pypi package would need to be updated